### PR TITLE
Troubleshoot build failure for package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-telegram-bot==20.8
-Pillow==10.1.0
+Pillow>=10.4.0
 pytesseract==0.3.10
 requests>=2.31.0
 python-dotenv>=1.0.0


### PR DESCRIPTION
Update Pillow dependency to version 10.4.0 or newer to fix build error on Python 3.13.