### PR TITLE
Resolve Telegram bot conflict error

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -27,8 +27,11 @@ def main():
         
         # הדפסת מידע על הפעלה
         port = Config.PORT
-        webhook_url = Config.WEBHOOK_URL
-        
+        # Determine webhook URL (explicit or derived)
+        webhook_url = Config.WEBHOOK_URL or (
+            f"https://{os.getenv('RENDER_EXTERNAL_HOSTNAME')}" if os.getenv('RENDER_EXTERNAL_HOSTNAME') else None
+        )
+
         logger.info(f"📡 Starting webhook bot on port {port}")
         if webhook_url:
             logger.info(f"🔗 Webhook URL: {webhook_url}")

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,18 @@
+services:
+  - type: web
+    name: telegram-ocr-bot
+    env: python
+    plan: free
+    buildCommand: pip install -r requirements.txt
+    startCommand: python -u deploy.py
+    autoDeploy: true
+    envVars:
+      - key: BOT_TOKEN
+        sync: false  # set in dashboard for security
+      - key: WEBHOOK_URL
+        fromService:
+          type: web
+          name: telegram-ocr-bot
+          property: url
+      - key: PORT
+        value: "8080"

--- a/webhook_bot.py
+++ b/webhook_bot.py
@@ -184,7 +184,14 @@ bot_instance = None
 async def init_bot():
     """אתחול הבוט"""
     global bot_instance
+    # Fallback: if WEBHOOK_URL not explicitly set, try building it from Render's external hostname
     webhook_url = os.getenv('WEBHOOK_URL')
+    if not webhook_url:
+        render_host = os.getenv("RENDER_EXTERNAL_HOSTNAME")
+        if render_host:
+            webhook_url = f"https://{render_host}"
+            logger.info(f"Derived WEBHOOK_URL from RENDER_EXTERNAL_HOSTNAME: {webhook_url}")
+
     bot_instance = TelegramOCRBot(Config.BOT_TOKEN, webhook_url)
     await bot_instance.initialize()
 


### PR DESCRIPTION
Configure bot for single Render Web Service with webhook to resolve Telegram Conflict error.

The `telegram.error.Conflict` arises when multiple bot instances or a webhook and polling attempt to receive updates simultaneously. This PR introduces a `render.yaml` Blueprint and adjusts code to ensure the bot runs as a single Web Service using a webhook, eliminating the conflict.